### PR TITLE
補README文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multiple-databases-backup
 
-Backup database dockers at the same time by one backup container securely.
+Backup database dockers by one backup container securely.
 
 [![Build Status](https://app.travis-ci.com/i3thuan5/multiple-databases-backup.svg?branch=main)](https://app.travis-ci.com/i3thuan5/multiple-databases-backup)
 [![GitHub](https://img.shields.io/github/license/i3thuan5/multiple-databases-backup)](https://github.com/i3thuan5/multiple-databases-backup/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ Or pass the varivable to `docker`:
 docker run --env-file .env ithuan/multiple-databases-backup
 ```
 
-The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`, the output is the original SQL.
+The decryption command is:
+
+1. Import the gpg private key if you didn't import, `gpg --import <gpg-private-key.rev>`.
+2. Decrypt the backups, `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`, the output is the original SQL.
 
 ### KEEP_EVERY_BACKUP_IN_HOURS
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Backup postgres, mariadb at the same time by docker one container.
 
 [![Build Status](https://app.travis-ci.com/i3thuan5/multiple-databases-backup.svg?branch=main)](https://app.travis-ci.com/i3thuan5/multiple-databases-backup)
+[![GitHub](https://img.shields.io/github/license/i3thuan5/multiple-databases-backup)](https://github.com/i3thuan5/multiple-databases-backup/blob/main/LICENSE)
 [![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/ithuan/multiple-databases-backup)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/ithuan/multiple-databases-backup/latest)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
 [![Docker Stars](https://img.shields.io/docker/stars/ithuan/multiple-databases-backup)](https://hub.docker.com/r/ithuan/multiple-databases-backup)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ services:
       BACKUP_KEEP_MONTHS: 6  # Optional, not implemented yet
 ```
 
-## Reference
+## Environment Variables
 
-`GPG_PUBLIC_KEY`: base64 format of GPG public key for asymmetric encryptions
+### GPG_PUBLIC_KEY
+This optional environment variable is used for asymmetric encryptions. It is base64 format of GPG public key.
 
 1. [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) if you don't have an existing GPG key.
 2. Get base64 format of GPG public key and save to `.env` env-file:
@@ -51,4 +52,3 @@ docker run --env-file .env ithuan/multiple-databases-backup
 ```
 
 The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`.
-  

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Only configuration is setting labels in database containers and setting storages
 
 ### Production Ready
 
-Compatiabily to docker compose, docker-swarm and k8s.
+Compatiabily to docker-compose, docker-swarm and k8s.
 
 ### Supporting S3 Remote Backup Natively
 
@@ -134,3 +134,47 @@ This optional environment variable is how many daily backups kept. The default v
 ### KEEP_MONTH_BACKUP_IN_MONTHS
 
 This optional environment variable is how many monthly backups kept. The default value is `36`. It means 36 months, 3 years.
+
+## Examples
+
+### docker-compose
+
+Keep `docker-compose.yml` simple and set the variables in `.env`.
+
+#### docker-compose.yml
+
+```
+version: '3'
+services:
+  backup:
+    image: ithuan/multiple-databases-backup
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      S3_ENDPOINT_URL:
+      S3_REGION:
+      S3_BUCKET:
+      S3_ACCESS_KEY_ID:
+      S3_SECRET_ACCESS_KEY:
+      SCHEDULE:
+      GPG_PUBLIC_KEY:
+      KEEP_EVERY_BACKUP_IN_HOURS:
+      KEEP_DAY_BACKUP_IN_DAYS:
+      KEEP_MONTH_BACKUP_IN_MONTHS:
+```
+
+#### .env
+
+The variables below are configurable. [GPG_PUBLIC_KEY](#GPG_PUBLIC_KEY) variables should be set by manually.
+```
+S3_ENDPOINT_URL=
+S3_REGION=
+S3_BUCKET=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+SCHEDULE='0 * * * *'  # Backuping every hour
+GPG_PUBLIC_KEY=
+KEEP_EVERY_BACKUP_IN_HOURS=72  # 72 hours, 3 days
+KEEP_DAY_BACKUP_IN_DAYS=90  # 90 days, 3 months.
+KEEP_MONTH_BACKUP_IN_MONTHS=36  # 36 months, 3 years
+```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ All backups are transfered to S3-compatiable remote storage to keep availability
 
 Using the crontab daemon to backup periodly is for operation daily. For emergency, backup container can backup immediately. Related: [SCHEDULE](#SCHEDULE).
 
+### Cleanuping Old Backup Files for Comprehensive Strategy
+
+After backuping, the containers will cleanup old backups. The cleanuping deletes all backups except for recently backups, daily backups and monthly backups. The keeping startegy can be configured. Related: [KEEP_EVERY_BACKUP_IN_HOURS](#KEEP_EVERY_BACKUP_IN_HOURS), [KEEP_DAY_BACKUP_IN_DAYS](#KEEP_DAY_BACKUP_IN_DAYS), [KEEP_MONTH_BACKUP_IN_MONTHS](#KEEP_MONTH_BACKUP_IN_MONTHS).
+
 ### Security
 
 Preserves the confientiality and intgerity of backup process and backup files. The backup process is built by shell pipeline, without leaving any temporary file in the disk. It also supports encrypting the backup files. Related: [GPG_PUBLIC_KEY](#GPG_PUBLIC_KEY).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # multiple-databases-backup
 Backup postgres, mariadb at the same time by docker one container.
 
+[![Build Status](https://app.travis-ci.com/i3thuan5/multiple-databases-backup.svg?branch=main)](https://app.travis-ci.com/i3thuan5/multiple-databases-backup)
+[![Docker Pulls](https://img.shields.io/docker/pulls/ithuan/multiple-databases-backup?style=plastic)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
+
 ## Quick Start
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Backup the containers containing the labels together.
 
 Only configuration is setting labels in database containers and setting storages and encryption variables in the backup container.
 
-### Production ready
+### Production Ready
 
 Compatiabily to docker compose, docker-swarm and k8s.
 
-### Supporting S3 Remote Backup natively
+### Supporting S3 Remote Backup Natively
 
 All backups are transfered to S3-compatiable remote storage to keep availability. Related: [S3_ENDPOINT_URL](#S3_ENDPOINT_URL), [S3_REGION](#S3_REGION), [S3_BUCKET](#S3_BUCKET), [S3_ACCESS_KEY_ID](#S3_ACCESS_KEY_ID), [S3_SECRET_ACCESS_KEY](#S3_SECRET_ACCESS_KEY).
 
@@ -97,7 +97,7 @@ This environment variable is required for S3 secret access key, as a string.
 
 ### SCHEDULE
 
-This optional environment variable is the backup schedule for backup. The format is crontab syntax containing settings for minute, hour, day of the month, month of the year and day of the week respectively. If this vairable is blank, the script will backup once and exit. The default value is ''.
+This optional environment variable is the backup schedule for backup. The format is crontab syntax containing settings for minute, hour, day of the month, month of the year and day of the week respectively. If this vairable is blank, the script will backup once and exit. The default value is blank.
 
 ### GPG_PUBLIC_KEY
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ services:
       S3_SECRET_ACCESS_KEY: secret
       SCHEDULE: "0 * * * *"  # Optional
       GPG_PUBLIC_KEY: ${GPG_PUBLIC_KEY:-}  # Optional
-      BACKUP_KEEP_MINS: 1440  # Optional, not implemented yet
-      BACKUP_KEEP_DAYS: 7  # Optional, not implemented yet
-      BACKUP_KEEP_WEEKS: 4  # Optional, not implemented yet
-      BACKUP_KEEP_MONTHS: 6  # Optional, not implemented yet
+      KEEP_EVERY_BACKUP_IN_HOURS: 72  # Optional
+      KEEP_DAY_BACKUP_IN_DAYS: 90  # Optional
+      KEEP_MONTH_BACKUP_IN_MONTHS: 36  # Optional
 ```
 
 ## Features
@@ -116,3 +115,15 @@ docker run --env-file .env ithuan/multiple-databases-backup
 ```
 
 The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`, the output is the original SQL.
+
+### KEEP_EVERY_BACKUP_IN_HOURS
+
+This optional environment variable is used for keeping backup files recently. The default value is 72.
+
+### KEEP_DAY_BACKUP_IN_DAYS
+
+The default value is 90.
+
+### KEEP_MONTH_BACKUP_IN_MONTHS
+
+The default value is 36.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # multiple-databases-backup
-Backup postgres, mariadb at the same time by docker one container.
+
+Backup database dockers at the same time by one backup container securely.
 
 [![Build Status](https://app.travis-ci.com/i3thuan5/multiple-databases-backup.svg?branch=main)](https://app.travis-ci.com/i3thuan5/multiple-databases-backup)
 [![GitHub](https://img.shields.io/github/license/i3thuan5/multiple-databases-backup)](https://github.com/i3thuan5/multiple-databases-backup/blob/main/LICENSE)
@@ -48,27 +49,27 @@ services:
 
 Backup the containers containing the labels together.
 
-### Configure Easily
+### Configuration Easily
 
 Only configuration is setting labels in database containers and setting storages and encryption variables in the backup container.
-
-### Support Remote Backup natively
-
-All backups are transfered to remote storage to keep availability. Related: [S3_ENDPOINT_URL](#S3_ENDPOINT_URL), [S3_REGION](#S3_REGION), [S3_BUCKET](#S3_BUCKET), [S3_ACCESS_KEY_ID](#S3_ACCESS_KEY_ID), [S3_SECRET_ACCESS_KEY](#S3_SECRET_ACCESS_KEY).
-
-### Support Backup Periodly and Backup once
-
-Using the crontab daemon to backup periodly is for operation daily. For emergency, backup container can backup immediately. Related: [SCHEDULE](#SCHEDULE).
 
 ### Production ready
 
 Compatiabily to docker compose, docker-swarm and k8s.
 
+### Supporting S3 Remote Backup natively
+
+All backups are transfered to S3-compatiable remote storage to keep availability. Related: [S3_ENDPOINT_URL](#S3_ENDPOINT_URL), [S3_REGION](#S3_REGION), [S3_BUCKET](#S3_BUCKET), [S3_ACCESS_KEY_ID](#S3_ACCESS_KEY_ID), [S3_SECRET_ACCESS_KEY](#S3_SECRET_ACCESS_KEY).
+
+### Supporting Backup Periodly and Backup once
+
+Using the crontab daemon to backup periodly is for operation daily. For emergency, backup container can backup immediately. Related: [SCHEDULE](#SCHEDULE).
+
 ### Security
 
-Preserves the confientiality and intgerity of backup process and backup files.
+Preserves the confientiality and intgerity of backup process and backup files. The backup process is built by shell pipeline, without leaving any temporary file in the disk. It also supports encrypting the backup files. Related: [GPG_PUBLIC_KEY](#GPG_PUBLIC_KEY).
 
-### Robust
+### Robustness
 
 Introducing to Continuous integration (CI) and dockerhub auto build to keep the backup script workable.
 
@@ -99,6 +100,7 @@ This environment variable is required for S3 secret access key, as a string.
 This optional environment variable is the backup schedule for backup. The format is crontab syntax containing settings for minute, hour, day of the month, month of the year and day of the week respectively. If this vairable is blank, the script will backup once and exit. The default value is ''.
 
 ### GPG_PUBLIC_KEY
+
 This optional environment variable is used for asymmetric encryptions. It is base64 format of GPG public key. The configuration steps are:
 
 1. [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) if you don't have an existing GPG key.

--- a/README.md
+++ b/README.md
@@ -117,10 +117,14 @@ Or pass the varivable to `docker`:
 ```bash
 docker run --env-file .env ithuan/multiple-databases-backup
 ```
+4. Export the private key and save it safely:
+```bash
+gpg --export-secret-keys --armor <GPG key ID> > <gpg-private-key.asc>
+```
 
 The decryption command is:
 
-1. Import the gpg private key if you didn't import, `gpg --import <gpg-private-key.rev>`.
+1. Import the gpg private key if you didn't import, `gpg --import <gpg-private-key.asc>`.
 2. Decrypt the backups, `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`, the output is the original SQL.
 
 ### KEEP_EVERY_BACKUP_IN_HOURS

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ services:
       KEEP_EVERY_BACKUP_IN_HOURS:
       KEEP_DAY_BACKUP_IN_DAYS:
       KEEP_MONTH_BACKUP_IN_MONTHS:
+    restart: always
 ```
 
 #### .env

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`, the ou
 
 ### KEEP_EVERY_BACKUP_IN_HOURS
 
-This optional environment variable is used for keeping backup files recently. The default value is 72.
+This optional environment variable is how old backups kept. The default value is `72`. It means 72 hours, 3 days.
 
 ### KEEP_DAY_BACKUP_IN_DAYS
 
-The default value is 90.
+This optional environment variable is how many daily backups kept. The default value is `90`. It means 90 days, 3 months.
 
 ### KEEP_MONTH_BACKUP_IN_MONTHS
 
-The default value is 36.
+This optional environment variable is how many monthly backups kept. The default value is `36`. It means 36 months, 3 years.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 Backup postgres, mariadb at the same time by docker one container.
 
 [![Build Status](https://app.travis-ci.com/i3thuan5/multiple-databases-backup.svg?branch=main)](https://app.travis-ci.com/i3thuan5/multiple-databases-backup)
-[![Docker Pulls](https://img.shields.io/docker/pulls/ithuan/multiple-databases-backup?style=plastic)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
+[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/ithuan/multiple-databases-backup)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/ithuan/multiple-databases-backup/latest)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
+[![Docker Stars](https://img.shields.io/docker/stars/ithuan/multiple-databases-backup)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
+[![Docker Pulls](https://img.shields.io/docker/pulls/ithuan/multiple-databases-backup)](https://hub.docker.com/r/ithuan/multiple-databases-backup)
+![GitHub Repo stars](https://img.shields.io/github/stars/i3thuan5/multiple-databases-backup?style=social)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Only configuration is setting labels in database containers and setting storages
 
 ### Production Ready
 
-Compatiabily to docker-compose, docker-swarm and k8s.
+Compatiabily to [docker-compose](#docker-compose), docker-swarm and k8s.
 
 ### Supporting S3 Remote Backup Natively
 
@@ -166,6 +166,7 @@ services:
 #### .env
 
 The variables below are configurable. [GPG_PUBLIC_KEY](#GPG_PUBLIC_KEY) variables should be set by manually.
+
 ```
 S3_ENDPOINT_URL=
 S3_REGION=
@@ -178,3 +179,7 @@ KEEP_EVERY_BACKUP_IN_HOURS=72  # 72 hours, 3 days
 KEEP_DAY_BACKUP_IN_DAYS=90  # 90 days, 3 months.
 KEEP_MONTH_BACKUP_IN_MONTHS=36  # 36 months, 3 years
 ```
+
+### Kubernetes(K8s)
+
+The containers can backup periodly by [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Only configuration is setting labels in database containers and setting storages
 
 ### Production Ready
 
-Compatiabily to [docker-compose](#docker-compose), docker-swarm and k8s.
+Compatiabily to [docker-compose](#docker-compose) and docker-swarm.
 
 ### Supporting S3 Remote Backup Natively
 
@@ -179,7 +179,3 @@ KEEP_EVERY_BACKUP_IN_HOURS=72  # 72 hours, 3 days
 KEEP_DAY_BACKUP_IN_DAYS=90  # 90 days, 3 months.
 KEEP_MONTH_BACKUP_IN_MONTHS=36  # 36 months, 3 years
 ```
-
-### Kubernetes(K8s)
-
-The containers can backup periodly by [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ services:
   postgres:
     image: postgres
     labels:
-      - backup.postgres=true
+      - backup.postgres=true  # Add label
+    environment:
+      POSTGRES_PASSWORD: secret
   mariadb:
     image: mariadb:10.6
     labels:
@@ -24,9 +26,29 @@ services:
       S3_ACCESS_KEY_ID: key
       S3_SECRET_ACCESS_KEY: secret
       S3_BUCKET: my-bucket
-      SCHEDULE: @daily  # Optional, not implemented yet
+      SCHEDULE: "0 * * * *"  # Optional
+      GPG_PUBLIC_KEY: ${GPG_PUBLIC_KEY:-}  # Optional
       BACKUP_KEEP_MINS: 1440  # Optional, not implemented yet
       BACKUP_KEEP_DAYS: 7  # Optional, not implemented yet
       BACKUP_KEEP_WEEKS: 4  # Optional, not implemented yet
       BACKUP_KEEP_MONTHS: 6  # Optional, not implemented yet
 ```
+
+## Reference
+
+`GPG_PUBLIC_KEY`: base64 format of GPG public key for asymmetric encryptions
+
+1. [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) if you don't have an existing GPG key.
+2. Get base64 format of GPG public key and save to `.env` env-file:
+```bash
+GPG_PUBLIC_KEY=`gpg --armor --export <GPG key ID> | base64 --wrap 0`
+echo "GPG_PUBLIC_KEY=${GPG_PUBLIC_KEY}" > .env
+```
+3. Run with `docker-compose`, `docker-compose` will [read `.env` automatically](https://docs.docker.com/compose/environment-variables/set-environment-variables/#substitute-with-an-env-file).
+Or pass the varivable to `docker`:
+```bash
+docker run --env-file .env ithuan/multiple-databases-backup
+```
+
+The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`.
+  

--- a/README.md
+++ b/README.md
@@ -36,8 +36,32 @@ services:
 
 ## Environment Variables
 
+### S3_ENDPOINT_URL
+
+This environment variable is required for S3 URL when connecting to S3, including scheme.
+
+### S3_REGION
+
+This optional environment variable is the name of the S3 region to use. (eg. eu-west-1)
+
+### S3_ACCESS_KEY_ID
+
+This environment variable is required for S3 access key, as a string.
+
+### S3_SECRET_ACCESS_KEY
+
+This environment variable is required for S3 secret access key, as a string.
+
+### S3_BUCKET
+
+This environment variable is required for S3 storage bucket name, as a string.
+
+### SCHEDULE
+
+This optional environment variable is the backup schedule for backup. The format is crontab syntax containing settings for minute, hour, day of the month, month of the year and day of the week respectively. If this vairable is blank, the script will backup once and exit. The default value is ''.
+
 ### GPG_PUBLIC_KEY
-This optional environment variable is used for asymmetric encryptions. It is base64 format of GPG public key.
+This optional environment variable is used for asymmetric encryptions. It is base64 format of GPG public key. The configuration steps are:
 
 1. [Generating a new GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) if you don't have an existing GPG key.
 2. Get base64 format of GPG public key and save to `.env` env-file:
@@ -51,4 +75,4 @@ Or pass the varivable to `docker`:
 docker run --env-file .env ithuan/multiple-databases-backup
 ```
 
-The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`.
+The decryption command is `gpg --decrypt <postgres15.sql.gz.gpg> | zcat`, the output is the original SQL.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ services:
     environment:
       S3_ENDPOINT_URL: https://domain.tw
       S3_REGION: region
+      S3_BUCKET: my-bucket
       S3_ACCESS_KEY_ID: key
       S3_SECRET_ACCESS_KEY: secret
-      S3_BUCKET: my-bucket
       SCHEDULE: "0 * * * *"  # Optional
       GPG_PUBLIC_KEY: ${GPG_PUBLIC_KEY:-}  # Optional
       BACKUP_KEEP_MINS: 1440  # Optional, not implemented yet
@@ -41,6 +41,36 @@ services:
       BACKUP_KEEP_WEEKS: 4  # Optional, not implemented yet
       BACKUP_KEEP_MONTHS: 6  # Optional, not implemented yet
 ```
+
+## Features
+
+### Backup Together
+
+Backup the containers containing the labels together.
+
+### Configure Easily
+
+Only configuration is setting labels in database containers and setting storages and encryption variables in the backup container.
+
+### Support Remote Backup natively
+
+All backups are transfered to remote storage to keep availability. Related: [S3_ENDPOINT_URL](#S3_ENDPOINT_URL), [S3_REGION](#S3_REGION), [S3_BUCKET](#S3_BUCKET), [S3_ACCESS_KEY_ID](#S3_ACCESS_KEY_ID), [S3_SECRET_ACCESS_KEY](#S3_SECRET_ACCESS_KEY).
+
+### Support Backup Periodly and Backup once
+
+Using the crontab daemon to backup periodly is for operation daily. For emergency, backup container can backup immediately. Related: [SCHEDULE](#SCHEDULE).
+
+### Production ready
+
+Compatiabily to docker compose, docker-swarm and k8s.
+
+### Security
+
+Preserves the confientiality and intgerity of backup process and backup files.
+
+### Robust
+
+Introducing to Continuous integration (CI) and dockerhub auto build to keep the backup script workable.
 
 ## Environment Variables
 
@@ -52,6 +82,10 @@ This environment variable is required for S3 URL when connecting to S3, includin
 
 This optional environment variable is the name of the S3 region to use. (eg. eu-west-1)
 
+### S3_BUCKET
+
+This environment variable is required for S3 storage bucket name, as a string.
+
 ### S3_ACCESS_KEY_ID
 
 This environment variable is required for S3 access key, as a string.
@@ -59,10 +93,6 @@ This environment variable is required for S3 access key, as a string.
 ### S3_SECRET_ACCESS_KEY
 
 This environment variable is required for S3 secret access key, as a string.
-
-### S3_BUCKET
-
-This environment variable is required for S3 storage bucket name, as a string.
 
 ### SCHEDULE
 


### PR DESCRIPTION
- 加隨時備份ê指令用法
- 加試驗。
- 加實作。
- 加SCEDULE設定毋著ê例。
- 修docker ignore檔案名。
- 用crontab - 比直接寫path好。
- 確定error log較好。
- 用正規表達驗證格式。
- 修travis 檢查試驗。
- 攏用bash，才有正規表達式。
- 查bash ê 正規表示法。
- Khioh RE。
- 學用 [^[:blank:]]
- 修試驗。
- 加鎖匙。
- Travis CI加gpg。
- 加密ê部份模組化。
- Key愛export，袂使用原始檔。
- 先hōo本底其他試驗會過。
- 修gpg import語法。
- docker run就會直接印log。
- 修指令
- .env ài kah compose.yml做伙。
- GPG_KEY改號做GPG_PUBLIC_KEY，較明。
- GPG_PRIVATE_KEY嘛註明。
- 修PRIVATE ê變數名。
- 修decrypt。
- passphrase改用檔案，按呢密碼袂hông記，較安全。
- 補GPG文件。
